### PR TITLE
Fix for #11

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -167,8 +167,5 @@
   { "keys": ["ctrl+x", "ctrl+c"], "command": "exit"},
   { "keys": ["ctrl+x", "ctrl+s"], "command": "save"},
 
-  { "keys": ["alt+x", "f", "f", "a", "p"], "command": "sbp_find_file_at_point" },
-
-  // Emacs style tabs
-  { "keys": ["tab"], "command": "reindent"}
+  { "keys": ["alt+x", "f", "f", "a", "p"], "command": "sbp_find_file_at_point" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -174,8 +174,5 @@
   { "keys": ["ctrl+x", "ctrl+s"], "command": "save"},
 
   // Other Emacs features
-  { "keys": ["alt+x", "f", "f", "a", "p"], "command": "sbp_find_file_at_point" },
-
-  // Emacs style tabs
-  { "keys": ["tab"], "command": "reindent"}
+  { "keys": ["alt+x", "f", "f", "a", "p"], "command": "sbp_find_file_at_point" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -168,8 +168,5 @@
   { "keys": ["ctrl+x", "ctrl+c"], "command": "exit"},
   { "keys": ["ctrl+x", "ctrl+s"], "command": "save"},
 
-  { "keys": ["alt+x", "f", "f", "a", "p"], "command": "sbp_find_file_at_point" },
-
-  // Emacs style tabs
-  { "keys": ["tab"], "command": "reindent"}
+  { "keys": ["alt+x", "f", "f", "a", "p"], "command": "sbp_find_file_at_point" }
 ]

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -1,0 +1,9 @@
+[
+    // Emacs style tabs
+    { "keys": ["tab"], "command": "reindent",  "context": [
+      { "key": "panel_has_focus",  "operand": false },
+      { "key": "auto_complete_visible", "operand": false },
+      { "key": "has_next_field", "operand": false },
+      { "key": "overlay_visible", "operand": false }]
+    }
+]


### PR DESCRIPTION
I added context conditions for tab keybiding to preserve tab expension and avoid using reindent in panel and overlay.
