### PR TITLE
Insert indent using alt+i 

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -194,6 +194,7 @@
   // Indentation  
   { "keys": ["ctrl+c", ">"], "command": "indent" },
   { "keys": ["ctrl+c", "<"], "command": "unindent" },
+  { "keys": ["alt+i"], "command": "insert", "args": {"characters": "\t" } },
   
   // Completion
   { "keys": ["alt+/"], "command": "auto_complete" },


### PR DESCRIPTION
Adds support for `insert indent` using `alt+i`
