### PR TITLE
Restore "find_under_expand" native functionality

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -189,7 +189,7 @@
   },
 
   // Search word under cursor in current file
-  { "keys": ["ctrl+alt+d"], "command": "find_under_expand" },
+  { "keys": ["shift+alt+d"], "command": "find_under_expand" },
   { "keys": ["ctrl+x", "ctrl+d"], "command": "find_under_expand_skip" },
 
   // Indentation  

--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -189,6 +189,7 @@
   },
 
   // Search word under cursor in current file
+  { "keys": ["ctrl+alt+d"], "command": "find_under_expand" },
   { "keys": ["ctrl+x", "ctrl+d"], "command": "find_under_expand_skip" },
 
   // Indentation  


### PR DESCRIPTION
Being able to add a selection to a multiple selection set is, to me, one of the killer feature of sublime text. So I arranged the keyboard map to bind ctrl-alt-d to "find_under_expand" behavior.

It's the most natural keymap to me, but might not be for anyone else. I think this feature should be binded to a keyboard shortcut in any way, even though it's not a native emacs feature.

Let me know what you think.
