### PR TITLE
Add: Emacs uppercase-lowercase region shortcuts

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -284,5 +284,9 @@
   { "keys": ["home"], "command": "move_to", "args": {"to": "bof"} },
   { "keys": ["end"], "command": "move_to", "args": {"to": "eof"} },
   { "keys": ["shift+end"], "command": "move_to", "args": {"to": "eof", "extend": true} },
-  { "keys": ["shift+home"], "command": "move_to", "args": {"to": "bof", "extend": true } }
+  { "keys": ["shift+home"], "command": "move_to", "args": {"to": "bof", "extend": true } },
+
+  // Capitalization commands
+  { "keys": ["ctrl+x", "ctrl+u"], "command": "upper_case" },
+	{ "keys": ["ctrl+x", "ctrl+l"], "command": "lower_case" }
 ]


### PR DESCRIPTION
Adds the `ctrl-x ctrl-u` and `ctrl-x ctrl-l` shortcuts for `upper_case` and `lower_case` st2 actions.
